### PR TITLE
Removed manual reset in example

### DIFF
--- a/examples/displayio_ssd1305_simpletest.py
+++ b/examples/displayio_ssd1305_simpletest.py
@@ -4,7 +4,6 @@ background, a smaller black rectangle, and some white text.
 """
 
 import board
-import digitalio
 import displayio
 import terminalio
 from adafruit_display_text import label
@@ -12,17 +11,12 @@ import adafruit_displayio_ssd1305
 
 displayio.release_displays()
 
-# Manually Toggle Reset
-reset = digitalio.DigitalInOut(board.D9)
-reset.switch_to_output(value=False)
-reset.value = True
-
 # Use for SPI
 spi = board.SPI()
 oled_cs = board.D5
 oled_dc = board.D6
 display_bus = displayio.FourWire(spi, command=oled_dc, chip_select=oled_cs,
-                                 baudrate=1000000)
+                                 baudrate=1000000, reset=board.D9)
 
 # Use for I2C
 # i2c = board.I2C()


### PR DESCRIPTION
Apparently unnecessary when hooked up to MicroController reset. I left the SPI reset for consistency with other drivers.