### PR TITLE
Remove usage of the set_vertical_scroll Display constructor parameter.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,6 @@ This is easily achieved by downloading
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-displayio_ssd1305/>`_. To install for current user:

--- a/adafruit_displayio_ssd1305.py
+++ b/adafruit_displayio_ssd1305.py
@@ -56,7 +56,14 @@ _INIT_SEQUENCE = (
 
 # pylint: disable=too-few-public-methods
 class SSD1305(displayio.Display):
-    """SSD1305 driver"""
+    """
+    SSD1305 driver
+
+    :param int width: The width of the display
+    :param int height: The height of the display
+    :param int rotation: The rotation of the display in degrees. Default is 0.
+        One of (0, 90, 180, 270)
+    """
 
     def __init__(self, bus, **kwargs):
         colstart = 0
@@ -80,7 +87,6 @@ class SSD1305(displayio.Display):
             set_column_command=0x21,
             set_row_command=0x22,
             data_as_commands=True,
-            set_vertical_scroll=0xD3,
             brightness_command=0x81,
             single_byte_bounds=True,
             colstart=colstart,


### PR DESCRIPTION
Remove usage of the deprecated `set_vertical_scroll` parameter - Ref: https://github.com/adafruit/circuitpython/issues/5189

Minor docs improvements.